### PR TITLE
Add OAuth social login test

### DIFF
--- a/docs/features/oauth-sign-up/oauth-sign-up.md
+++ b/docs/features/oauth-sign-up/oauth-sign-up.md
@@ -1,0 +1,17 @@
+# OAuth Sign-Up Feature Report
+
+## Overview
+
+This update introduces OAuth sign-up and login using Google, Facebook, Twitter, and LinkedIn. Users can authenticate with these providers via Laravel Socialite. On a successful callback, user records are created or linked and the user is redirected to the dashboard.
+
+## Implementation Details
+
+- **Routes**: Social login redirect and callback routes were already defined in `routes/auth.php`.
+- **Controller**: `SocialiteController` handles fetching the social profile, creating or updating a `User`, storing OAuth identifiers and tokens, and logging the user in.
+- **Frontend**: `SocialLoginButtons` component renders buttons for the four providers. These buttons appear on both the registration and login pages.
+- **Testing**: Added a Pest test `tests/Feature/Auth/SocialLoginTest.php` which mocks Socialite and verifies that a new user can log in via Google, is redirected to the dashboard, and that provider fields are stored.
+
+## Rationale
+
+Adding OAuth sign-up reduces the friction for new users by allowing them to authenticate using existing social accounts. Storing provider identifiers enables future account management features. The test ensures the integration works without requiring real OAuth requests by mocking the Socialite provider.
+

--- a/tests/Feature/Auth/SocialLoginTest.php
+++ b/tests/Feature/Auth/SocialLoginTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\User;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery; // for mocking Socialite
+
+it('logs in via google', function () {
+    // Prepare fake socialite user
+    $abstractUser = Mockery::mock(SocialiteUser::class);
+    $abstractUser->shouldReceive('getId')->andReturn('google123');
+    $abstractUser->shouldReceive('getEmail')->andReturn('google@example.com');
+    $abstractUser->shouldReceive('getName')->andReturn('Google User');
+    $abstractUser->token = 'token';
+    $abstractUser->refreshToken = 'refresh';
+
+    // Mock the provider
+    $provider = Mockery::mock(Provider::class);
+    $provider->shouldReceive('user')->andReturn($abstractUser);
+
+    Socialite::shouldReceive('driver')->with('google')->andReturn($provider);
+
+    // Hit the callback route
+    $response = $this->get('/auth/google/callback');
+
+    $response->assertRedirect(route('dashboard', absolute: false));
+
+    // User created and authenticated
+    $this->assertAuthenticated();
+    $user = User::first();
+    expect($user->provider)->toBe('google')
+        ->and($user->provider_id)->toBe('google123');
+});


### PR DESCRIPTION
## Summary
- document OAuth sign-up feature
- add a Pest test for Google OAuth login

## Testing
- `npm run format`
- ❌ `composer install` *(command not found)*
- ❌ `./vendor/bin/pint` *(command not found)*
- ❌ `./vendor/bin/pest` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862035dd5f083288f82a30e34c3d5dc