### PR TITLE
Add remember me test and login feature doc

### DIFF
--- a/docs/features/paralegal/paralegal.md
+++ b/docs/features/paralegal/paralegal.md
@@ -1,0 +1,16 @@
+# Login Feature Implementation
+
+This document summarizes the steps performed to implement the email/password login feature with a **Remember Me** option.
+
+## Overview
+
+The existing codebase already included Laravel's built-in authentication routes and UI using Inertia and React. After confirming there was no `.junie` directory containing additional instructions, the following tasks were completed:
+
+1. Reviewed authentication controllers and React pages to ensure an email, password and `remember` checkbox are present.
+2. Confirmed the login request uses Laravel's `Auth::attempt` with the `remember` flag.
+3. Added an automated Pest test verifying that checking the `remember` option sets the recaller cookie.
+
+## Testing
+
+Automated tests could not be executed in this environment because PHP and Composer dependencies are absent by default and network restrictions block retrieving Composer. The added test should pass in a full Laravel environment.
+

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -39,3 +39,18 @@ test('users can logout', function () {
     $this->assertGuest();
     $response->assertRedirect('/');
 });
+
+test('remember me sets recaller cookie', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+        'remember' => true,
+    ]);
+
+    $response->assertRedirect(route('dashboard', absolute: false));
+
+    $recallerName = \Illuminate\Support\Facades\Auth::getRecallerName();
+    $response->assertCookie($recallerName);
+});


### PR DESCRIPTION
## Summary
- add a new Pest test to verify the remember-me cookie is set
- document the login feature implementation in `docs/features/paralegal/paralegal.md`

## Testing
- `pest` *(fails: vendor binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_686203fbfe0c8328a23ce7602b0cd59c