### PR TITLE
Add forgot password flow

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -97,4 +97,12 @@ class User extends Authenticatable
         $this->last_name = array_pop($nameParts);
         $this->middle_name = count($nameParts) > 0 ? implode(' ', $nameParts) : null;
     }
+
+    /**
+     * Send the password reset notification using our custom notification.
+     */
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify(new \App\Notifications\ResetPasswordNotification($token));
+    }
 }

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordBase;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPasswordNotification extends ResetPasswordBase
+{
+    /**
+     * Build the mail representation of the notification.
+     */
+    public function toMail($notifiable): MailMessage
+    {
+        $url = $this->resetUrl($notifiable);
+
+        return (new MailMessage())
+            ->subject('Reset your password')
+            ->markdown('emails.auth.reset-password', ['url' => $url]);
+    }
+}

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -14,7 +14,7 @@ class ResetPasswordNotification extends ResetPasswordBase
     {
         $url = $this->resetUrl($notifiable);
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->subject('Reset your password')
             ->markdown('emails.auth.reset-password', ['url' => $url]);
     }

--- a/docs/epics-and-user-stories.md
+++ b/docs/epics-and-user-stories.md
@@ -26,6 +26,8 @@ prompts below are written for ChatGPT Codex to implement each user story. The
 project uses Laravel 12 with Inertia and React 19. Format code with Prettier and
 keep tests in Pest.
 
+- **Forgot Password Flow**: users can request a reset link and choose a new password.
+
 ### Codex Prompt 1: Email Registration
 
 **Context**

--- a/resources/views/emails/auth/reset-password.blade.php
+++ b/resources/views/emails/auth/reset-password.blade.php
@@ -1,0 +1,15 @@
+@component('mail::message')
+# Reset your password
+
+We received a request to reset your password. Click the button below to choose a new one.
+
+@component('mail::button', ['url' => $url])
+Reset Password
+@endcomponent
+
+This link will expire in {{ config('auth.passwords.'.config('auth.defaults.passwords').'.expire') }} minutes.
+If you didn't request a password reset, feel free to ignore this email.
+
+Thanks,
+{{ config('app.name') }} Team
+@endcomponent

--- a/tests/Feature/Auth/ForgotPasswordFlowTest.php
+++ b/tests/Feature/Auth/ForgotPasswordFlowTest.php
@@ -25,7 +25,7 @@ it('allows a user to reset a forgotten password', function () {
             'password' => 'new-password',
             'password_confirmation' => 'new-password',
         ])->assertRedirect(route('login'))
-          ->assertSessionHas('status');
+            ->assertSessionHas('status');
 
         return true;
     });


### PR DESCRIPTION
## Summary
- add custom `ResetPasswordNotification`
- override sending on `User`
- create branded reset password email view
- document the feature under the User Onboarding epic
- cover the flow with a new Pest test
- fix custom notification method signature

## Testing
- `./vendor/bin/pest -v` *(fails: No such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862087989e08328a018ce24a9c86e0a