### PR TITLE
Add forgot password flow

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -97,5 +97,4 @@ class User extends Authenticatable
         $this->last_name = array_pop($nameParts);
         $this->middle_name = count($nameParts) > 0 ? implode(' ', $nameParts) : null;
     }
-
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -97,4 +97,5 @@ class User extends Authenticatable
         $this->last_name = array_pop($nameParts);
         $this->middle_name = count($nameParts) > 0 ? implode(' ', $nameParts) : null;
     }
+
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Notifications\Messages\MailMessage;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        ResetPassword::toMailUsing(function ($notifiable, string $token) {
+            $url = url(route('password.reset', ['token' => $token, 'email' => $notifiable->getEmailForPasswordReset()], false));
+
+            return (new MailMessage())
+                ->subject('Reset your password')
+                ->markdown('emails.auth.reset-password', [
+                    'url' => $url,
+                ]);
+        });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,7 +24,7 @@ class AppServiceProvider extends ServiceProvider
         ResetPassword::toMailUsing(function ($notifiable, string $token) {
             $url = url(route('password.reset', ['token' => $token, 'email' => $notifiable->getEmailForPasswordReset()], false));
 
-            return (new MailMessage())
+            return (new MailMessage)
                 ->subject('Reset your password')
                 ->markdown('emails.auth.reset-password', [
                     'url' => $url,

--- a/docs/epics-and-user-stories.md
+++ b/docs/epics-and-user-stories.md
@@ -26,6 +26,8 @@ prompts below are written for ChatGPT Codex to implement each user story. The
 project uses Laravel 12 with Inertia and React 19. Format code with Prettier and
 keep tests in Pest.
 
+- **Forgot Password Flow**: users can request a reset link and choose a new password.
+
 ### Codex Prompt 1: Email Registration
 
 **Context**

--- a/resources/views/emails/auth/reset-password.blade.php
+++ b/resources/views/emails/auth/reset-password.blade.php
@@ -1,0 +1,15 @@
+@component('mail::message')
+# Reset your password
+
+We received a request to reset your password. Click the button below to choose a new one.
+
+@component('mail::button', ['url' => $url])
+Reset Password
+@endcomponent
+
+This link will expire in {{ config('auth.passwords.'.config('auth.defaults.passwords').'.expire') }} minutes.
+If you didn't request a password reset, feel free to ignore this email.
+
+Thanks,
+{{ config('app.name') }} Team
+@endcomponent

--- a/tests/Feature/Auth/ForgotPasswordFlowTest.php
+++ b/tests/Feature/Auth/ForgotPasswordFlowTest.php
@@ -25,7 +25,7 @@ it('allows a user to reset a forgotten password', function () {
             'password' => 'new-password',
             'password_confirmation' => 'new-password',
         ])->assertRedirect(route('login'))
-          ->assertSessionHas('status');
+            ->assertSessionHas('status');
 
         return true;
     });

--- a/tests/Feature/Auth/ForgotPasswordFlowTest.php
+++ b/tests/Feature/Auth/ForgotPasswordFlowTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+
+it('allows a user to reset a forgotten password', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    // Request reset link
+    $this->post(route('password.email'), ['email' => $user->email])
+        ->assertSessionHas('status');
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+        // Visit reset form
+        $this->get(route('password.reset', ['token' => $notification->token, 'email' => $user->email]))
+            ->assertOk();
+
+        // Submit new password
+        $this->post(route('password.store'), [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ])->assertRedirect(route('login'))
+          ->assertSessionHas('status');
+
+        return true;
+    });
+});


### PR DESCRIPTION
## Summary
- add custom view for password reset email
- configure ResetPassword notification to use the branded view
- document the forgot password flow in the onboarding epic
- cover reset flow with a new Pest test

## Testing
- `./vendor/bin/pest -v` *(fails: No such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862087989e08328a018ce24a9c86e0a