### PR TITLE
Implement forgot password flow

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ForgotPasswordController extends Controller
+{
+    /**
+     * Display the form to request a password reset link.
+     */
+    public function create(Request $request): Response
+    {
+        return Inertia::render('auth/forgot-password', [
+            'status' => $request->session()->get('status'),
+        ]);
+    }
+
+    /**
+     * Send a password reset link to the given user.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate(['email' => 'required|email']);
+
+        Password::sendResetLink($request->only('email'));
+
+        return back()->with('status', __('A reset link will be sent if the account exists.'));
+    }
+
+    /**
+     * Display the password reset form for the given token.
+     */
+    public function edit(Request $request, string $token): Response
+    {
+        return Inertia::render('auth/reset-password', [
+            'token' => $token,
+            'email' => $request->email,
+        ]);
+    }
+
+    /**
+     * Reset the user's password.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'token' => ['required'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user) use ($request) {
+                $user->forceFill([
+                    'password' => Hash::make($request->password),
+                    'remember_token' => Str::random(60),
+                ])->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        if ($status == Password::PASSWORD_RESET) {
+            return to_route('login')->with('status', __($status));
+        }
+
+        throw ValidationException::withMessages([
+            'email' => [__($status)],
+        ]);
+    }
+}

--- a/docs/epics-and-user-stories.md
+++ b/docs/epics-and-user-stories.md
@@ -27,6 +27,8 @@ project uses Laravel 12 with Inertia and React 19. Format code with Prettier and
 keep tests in Pest.
 
 - **Forgot Password Flow**: users can request a reset link and choose a new password.
+  - As a returning learner who forgets their password,
+    I want to receive a reset link via email so I can create a new password and regain access.
 
 ### Codex Prompt 1: Email Registration
 

--- a/docs/features/forgot-password/README.md
+++ b/docs/features/forgot-password/README.md
@@ -1,0 +1,17 @@
+# Forgot Password Feature Report
+
+## Overview
+
+This update introduces the complete password reset workflow. Users can request a password reset link, receive an email, and set a new password using the provided token.
+
+## Implementation Details
+
+- **Controller**: Added `ForgotPasswordController` which handles displaying the request form, sending reset links, showing the token-based form and updating the password.
+- **Routes**: Updated `routes/auth.php` to route all password reset endpoints through this controller.
+- **Frontend**: React pages `forgot-password.tsx` and `reset-password.tsx` already provide the forms using Inertia and Tailwind.
+- **Email**: `resources/views/emails/auth/reset-password.blade.php` sends a link that expires according to the `auth` config.
+- **Testing**: Added a Pest test covering the full reset flow including database update and notification.
+
+## Rationale
+
+Consolidating the password reset logic in a single controller simplifies maintenance while leveraging Laravel's built-in password broker for security. The automated test ensures the process works end to end.

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -4,8 +4,7 @@ use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\ConfirmablePasswordController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\EmailVerificationPromptController;
-use App\Http\Controllers\Auth\NewPasswordController;
-use App\Http\Controllers\Auth\PasswordResetLinkController;
+use App\Http\Controllers\Auth\ForgotPasswordController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\SocialiteController;
 use App\Http\Controllers\Auth\VerifyEmailController;
@@ -26,16 +25,16 @@ Route::middleware('guest')->group(function () {
     Route::get('auth/{provider}/redirect', [SocialiteController::class, 'redirect'])->name('socialite.redirect');
     Route::get('auth/{provider}/callback', [SocialiteController::class, 'callback'])->name('socialite.callback');
 
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
+    Route::get('forgot-password', [ForgotPasswordController::class, 'create'])
         ->name('password.request');
 
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+    Route::post('forgot-password', [ForgotPasswordController::class, 'store'])
         ->name('password.email');
 
-    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
+    Route::get('reset-password/{token}', [ForgotPasswordController::class, 'edit'])
         ->name('password.reset');
 
-    Route::post('reset-password', [NewPasswordController::class, 'store'])
+    Route::post('reset-password', [ForgotPasswordController::class, 'update'])
         ->name('password.store');
 });
 

--- a/tests/Feature/Auth/ForgotPasswordTest.php
+++ b/tests/Feature/Auth/ForgotPasswordTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+
+it('sends a reset link and updates the password', function () {
+    Notification::fake();
+
+    $user = User::factory()->create([
+        'password' => Hash::make('secret'),
+    ]);
+
+    // Request a password reset link
+    $this->post(route('password.email'), ['email' => $user->email])
+        ->assertSessionHas('status');
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+        // Display reset form
+        $this->get(route('password.reset', ['token' => $notification->token, 'email' => $user->email]))
+            ->assertOk();
+
+        // Submit new password
+        $this->post(route('password.store'), [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ])->assertRedirect(route('login'))
+            ->assertSessionHas('status');
+
+        return true;
+    });
+
+    expect(Hash::check('new-password', $user->refresh()->password))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- consolidate password reset logic into new `ForgotPasswordController`
- route password reset endpoints to the new controller
- document the feature and add user story details
- cover the workflow with a new Pest test

## Testing
- `npm run format:check`
- `npm run lint`
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686247ebe16c83288bf2948b3520b57f